### PR TITLE
Fixed sorting

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: coxphf
-Version: 1.13.3
-Date: 2023-07-18
+Version: 1.13.4
+Date: 2023-08-09
 Title: Cox Regression with Firth's Penalized Likelihood
 Authors@R: c(person("Georg", "Heinze", role=c("aut", "cre"), email="georg.heinze@meduniwien.ac.at"),
 			 person("Meinhard", "Ploner", role=c("aut")), 

--- a/R/coxphf.R
+++ b/R/coxphf.R
@@ -159,7 +159,8 @@ function(
   }
   
 
-	obj <- decomposeSurv(formula, data, sort = FALSE)
+	obj <- decomposeSurv(formula, data, sort = TRUE)
+	id <- as.numeric(rownames(obj$resp)) # this id is the row index before sorting
   NTDE <- obj$NTDE
 	mmm <- cbind(obj$mm1, obj$timedata)
         
@@ -213,7 +214,7 @@ function(
               method.ties = "breslow", n = n, ##terms = terms(formula),
               y = obj$resp, formula = formula, call = match.call())
   fit$means <- apply(mmm, 2, mean)
-  fit$linear.predictors <- as.vector(scale(mmm, fit$means, scale=FALSE) %*% coefs)
+  fit$linear.predictors[id] <- as.vector(scale(mmm, fit$means, scale=FALSE) %*% coefs)
 	if(fit$iter>=maxit) warning("Convergence for parameter estimation not attained in ", maxit, " iterations.\n")
   if(firth) fit$method <- "Penalized ML"
   else fit$method <- "Standard ML"

--- a/R/coxphf.R
+++ b/R/coxphf.R
@@ -158,9 +158,12 @@ function(
     return(fit)
   }
   
-
+  # Note that sorting is important because the Fortran code below expects
+  # the data to be sorted by time and status
 	obj <- decomposeSurv(formula, data, sort = TRUE)
-	id <- as.numeric(rownames(obj$resp)) # this id is the row index before sorting
+	
+	# id is the row index before sorting (needed to correctly match the linear predictor later)
+	id <- as.numeric(rownames(obj$resp)) 
   NTDE <- obj$NTDE
 	mmm <- cbind(obj$mm1, obj$timedata)
         


### PR DESCRIPTION
This fixes the sorting problem, since not sorting was actually incorrect. Now, sorting is done as before, but the linear predictor is then sorted to match the initial order. Now, the results should be correct again.